### PR TITLE
fix: remove KiKit stencil outputs from KiBot config

### DIFF
--- a/kibot.yaml
+++ b/kibot.yaml
@@ -719,17 +719,6 @@ outputs:
   options:
     template: full_SVG
     do_convert: true
-- name: basic_stencil_3d
-  comment: 3D self-registering stencil
-  type: stencil_3d
-  dir: Assembly
-- name: basic_stencil_for_jig
-  comment: Steel stencil for alignment jig
-  type: stencil_for_jig
-  dir: Assembly
-  options:
-    jigwidth: 100
-    jigheight: 100
 - name: basic_svg_sch_print
   comment: Schematic in SVG format
   type: svg_sch_print


### PR DESCRIPTION
## Summary
- Remove `basic_stencil_3d` and `basic_stencil_for_jig` outputs from `kibot.yaml`
- These fail when the PCB exceeds the hardcoded 100x100mm jig size
- Stencil generation is project-specific and should be added per-project if needed

## Test plan
- [ ] Verify KiBot CI pipeline passes without stencil outputs

🤖 Generated with [Claude Code](https://claude.com/claude-code)