### PR TITLE
chore: upgrade GitHub Actions to Node.js 24-compatible versions

### DIFF
--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -11,7 +11,7 @@ jobs:
       contents: write          # push branch
       pull-requests: write     # create PR
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with: { fetch-depth: 0 }
 
       - name: Install Commitizen

--- a/.github/workflows/module-kibot.yml
+++ b/.github/workflows/module-kibot.yml
@@ -9,7 +9,7 @@ jobs:
     container: ghcr.io/inti-cmnb/kicad9_auto_full:latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: "0"
 
@@ -81,21 +81,21 @@ jobs:
         run: ls -al out || echo "No output directory found."
 
       - name: Upload all results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ github.event.repository.name }}-${{ steps.git_desc.outputs.desc }}-full
           path: out/*
 
       - name: Upload Schematics
         if: ${{ always() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ github.event.repository.name }}-${{ steps.git_desc.outputs.desc }}-schematics
           path: out/Schematic/*schematic.pdf
 
       - name: Upload DigiKey BOM
         if: ${{ always() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ github.event.repository.name }}-${{ steps.git_desc.outputs.desc }}-marinecircuits-bom-digikey
           path: out/BOM/MarineCircuits/*.csv

--- a/.github/workflows/tag-release-merge.yml
+++ b/.github/workflows/tag-release-merge.yml
@@ -20,7 +20,7 @@ jobs:
     outputs:
       version: ${{ steps.version.outputs.version }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -56,7 +56,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -83,7 +83,7 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       - name: Download build artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: ${{ github.event.repository.name }}-${{ steps.git_desc.outputs.tag }}-full
           path: dist/


### PR DESCRIPTION
## Summary
- `actions/checkout` v4 → v6
- `actions/upload-artifact` v4 → v7
- `actions/download-artifact` v4 → v8

GitHub is deprecating Node.js 20 actions and will force Node.js 24 by default from **June 2, 2026**. These newer major versions run on `node24`.

## Test plan
- [ ] Verify `module-kibot.yml` runs successfully (KiBot generates outputs)
- [ ] Verify `create-release-pr.yml` runs successfully (release PR created)
- [ ] Verify `tag-release-merge.yml` runs successfully (tag + release published)

🤖 Generated with [Claude Code](https://claude.com/claude-code)